### PR TITLE
Pass in the current captures to custom operations

### DIFF
--- a/OAT.Tests/VehicleDemo.cs
+++ b/OAT.Tests/VehicleDemo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CST.OAT.Tests
             return ((VehicleRule)analyzer.Analyze(rules, vehicle).MaxBy(x => x.Severity).FirstOrDefault())?.Cost ?? 0;
         }
 
-        public (bool Applies, bool Result, ClauseCapture? Capture) OverweightOperationDelegate(Clause clause, object? state1, object? state2)
+        public (bool Applies, bool Result, ClauseCapture? Capture) OverweightOperationDelegate(Clause clause, object? state1, object? state2, IEnumerable<ClauseCapture>? captures)
         {
             if (clause.CustomOperation == "OVERWEIGHT")
             {

--- a/OAT/Strings.cs
+++ b/OAT/Strings.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CST.OAT.Utils
                         {
                             var keyStr = dictionaryEntry.Key.ToString();
                             var valueStr = dictionaryEntry.Value?.ToString();
-                            if (!string.IsNullOrEmpty(keyStr) && !string.IsNullOrEmpty(valueStr))
+                            if (keyStr is string && valueStr is string)
                                 stringList.Add(keyStr, valueStr);
                         }
                     }


### PR DESCRIPTION
They can then make decisions based on the previous captures.  Does not change how expressions are evaluted.  You will only get the results for the already evaluated (to the left) clauses