### PR TITLE
Fix for Scaffold choosing sub object constructors

### DIFF
--- a/OAT.Blazor.Components/Scaffold.cs
+++ b/OAT.Blazor.Components/Scaffold.cs
@@ -16,11 +16,7 @@ namespace Microsoft.CST.OAT.Blazor.Components
         public Scaffold(ConstructorInfo constructorToUse)
         {
             Constructor = constructorToUse;
-            PopulateParameters();
-        }
 
-        public void PopulateParameters()
-        {
             foreach (var parameter in Constructor.GetParameters() ?? Array.Empty<ParameterInfo>())
             {
                 if (parameter.HasDefaultValue)
@@ -35,7 +31,7 @@ namespace Microsoft.CST.OAT.Blazor.Components
                     }
                     else
                     {
-                        if (parameter.ParameterType.GetConstructors().FirstOrDefault() is ConstructorInfo constructor)
+                        if (parameter.ParameterType.GetConstructors().Where(x => Helpers.ConstructedOfBasicTypes(x)).FirstOrDefault() is ConstructorInfo constructor)
                         {
                             Parameters.Add(parameter.Name, new Scaffold(constructor));
                         }


### PR DESCRIPTION
Scaffold would previously choose the first constructor available for subobjects, this changes it to use one we know how to represent (using basic types)