### PR TITLE
ConstructedOfLoadedTypes improved

### DIFF
--- a/OAT.Tests/HelpersTest.cs
+++ b/OAT.Tests/HelpersTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CST.OAT.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
+using Microsoft.CST.OAT.VehicleDemo;
 
 namespace Microsoft.CST.OAT.Tests
 {
@@ -23,6 +24,30 @@ namespace Microsoft.CST.OAT.Tests
             }
         }
 
+        public class TestClass3
+        {
+            public TestClass3(string _)
+            {
+
+            }
+        }
+
+        public class TestClass4
+        {
+            public TestClass4(TestClass tc, TestClass3 tc3)
+            {
+
+            }
+        }
+
+        public class TestClass5
+        {
+            public TestClass5(Vehicle v)
+            {
+
+            }
+        }
+
         [ClassInitialize]
         public static void ClassSetup(TestContext _)
         {
@@ -33,8 +58,12 @@ namespace Microsoft.CST.OAT.Tests
         [TestMethod]
         public void TestConstructedOfLoadedTypes()
         {
-            Assert.IsFalse(Helpers.ConstructedOfLoadedTypes(typeof(TestClass)));
-            Assert.IsTrue(Helpers.ConstructedOfLoadedTypes(typeof(TestClass), new Assembly[] { typeof(TestClass).Assembly }));
+            Assert.IsTrue(Helpers.ConstructedOfLoadedTypes(typeof(TestClass)));
+            Assert.IsTrue(Helpers.ConstructedOfLoadedTypes(typeof(TestClass2)));
+            Assert.IsTrue(Helpers.ConstructedOfLoadedTypes(typeof(TestClass3)));
+            Assert.IsTrue(Helpers.ConstructedOfLoadedTypes(typeof(TestClass4)));
+            Assert.IsFalse(Helpers.ConstructedOfLoadedTypes(typeof(TestClass5)));
+            Assert.IsTrue(Helpers.ConstructedOfLoadedTypes(typeof(TestClass5), new Assembly[] { typeof(Vehicle).Assembly }));
         }
     }
 }

--- a/OAT/Helpers.cs
+++ b/OAT/Helpers.cs
@@ -168,6 +168,11 @@ namespace Microsoft.CST.OAT.Utils
                 }
                 else
                 {
+                    if (constructorInfo.DeclaringType.Assembly.GetTypes().Contains(parameter.ParameterType))
+                    {
+                        continue;
+                    }
+                    
                     if (extraAssemblies != null)
                     {
                         var validAssembly = extraAssemblies.Where(x => x.GetTypes().Contains(parameter.ParameterType)).FirstOrDefault();


### PR DESCRIPTION
Now implicitly assumes you have the assembly for the provided type/constructor.

Added new test cases.