### PR TITLE
Downgrade newtonsoft

### DIFF
--- a/OAT/OAT.csproj
+++ b/OAT/OAT.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="System.Collections" Version="4.3.0" />


### PR DESCRIPTION
Other programs that include OAT (https://github.com/microsoft/DevSkim/issues/285) are seeing that the newtonsoft 13.0.1 binary fails to load throwing exceptions.  OAT requiring 13 means that they cannot upgrade.  This downgrades back to newtonsoft json 12 which seems to work fine.

See https://github.com/JamesNK/Newtonsoft.Json/issues/2534