### PR TITLE
Print out friendly names for types

### DIFF
--- a/OAT.Blazor.Components/Inputs/DictionaryObjectObject.razor
+++ b/OAT.Blazor.Components/Inputs/DictionaryObjectObject.razor
@@ -3,8 +3,8 @@
 @using System.Reflection
 
 <div class="row">
-    <div class="col underline">Key : @dictionaryKeyType.Name</div>
-    <div class="col underline">Value : @dictionaryValueType.Name</div>
+    <div class="col underline">Key : @dictionaryKeyType?.GetFriendlyName()</div>
+    <div class="col underline">Value : @dictionaryValueType?.GetFriendlyName()</div>
     <div class="col"></div>
 </div>
 <div class="row">
@@ -36,7 +36,7 @@
 {
     <div class="row">
         <div class="col-2 underline">
-            <span>Key : @dictionaryKeyType.Name</span>
+            <span>Key : @dictionaryKeyType?.GetFriendlyName()</span>
         </div>
         <div class="col">
             <select class="form-control" @bind="SelectedKey">
@@ -52,7 +52,7 @@
     </div>
     <div class="row">
         <div class="col-2 underline">
-            <span>Value : @dictionaryValueType.Name</span>
+            <span>Value : @dictionaryValueType?.GetFriendlyName()</span>
         </div>
         <div class="col">
         @if (Keys.Count > 0)

--- a/OAT.Blazor.Components/Inputs/ObjectInput.razor
+++ b/OAT.Blazor.Components/Inputs/ObjectInput.razor
@@ -6,7 +6,7 @@
     case ItemState.Expanded:
         <button class="btn btn-primary" type="button" @onclick="Collapse">
             <span class="oi oi-chevron-top mx-3"></span>
-            <span>@Helpers.GetValueByPropertyOrFieldName(Object, SubPath)?.GetType().Name</span>
+            <span>@SubProperty?.GetType().GetFriendlyName()</span>
         </button>
         <div class="object-properties">
             @for (int i = 0; i < Properties.Length; i++)
@@ -17,7 +17,7 @@
                     var appendedName = AppendNameToPath(Properties[i].Name);
                     var name = ToName(appendedName, i);
                     <div class="form-group">
-                        <label for="@name"><b>@Properties[i].Name</b> : @Properties[i].PropertyType.Name</label>
+                        <label for="@name"><b>@Properties[i].Name</b> : @Properties[i].PropertyType.GetFriendlyName()</label>
                         <PropertyInput Object="@Object" SubPath="@appendedName" id="@name" type="@type" isDisabled="@(!Properties[i].CanWrite)" onChangeAction="@onChangeAction"/>
                     </div>
                 }
@@ -32,7 +32,7 @@
                     var appendedName = AppendNameToPath(Fields[i].Name);
                     var name = ToName(appendedName, i);
                     <div class="form-group">
-                        <label for="@name"><b>@Fields[i].Name</b> : @Fields[i].FieldType.Name</label>
+                        <label for="@name"><b>@Fields[i].Name</b> : @Fields[i].FieldType.GetFriendlyName()</label>
                         <PropertyInput Object="@Object" SubPath="@appendedName" id="@name" type="@type" isDisabled="false" onChangeAction="@onChangeAction"/>
                     </div>
                 }
@@ -42,7 +42,7 @@
     case ItemState.Collapsed:
         <button class="btn btn-primary" type="button" @onclick="Expand">
             <span class="oi oi-chevron-bottom mx-3"></span>
-            <span>@Helpers.GetValueByPropertyOrFieldName(Object, SubPath)?.GetType().Name</span>
+            <span>@SubProperty?.GetType().GetFriendlyName()</span>
         </button>
         break;
 }
@@ -90,6 +90,8 @@
     {
         itemState = ItemState.Collapsed;
     }
+
+    object? SubProperty => Helpers.GetValueByPropertyOrFieldName(Object, SubPath);
 
     public string AppendNameToPath(string Name)
     {

--- a/OAT.Blazor.Components/Inputs/PropertyInput.razor
+++ b/OAT.Blazor.Components/Inputs/PropertyInput.razor
@@ -95,14 +95,14 @@
             }
             else
             {
-                <ListObjectInput id="@id" Object="Object" SubPath="@SubPath" listType="listType" buttonText="@listType.Name" />
+                <ListObjectInput id="@id" Object="Object" SubPath="@SubPath" listType="listType" buttonText="@listType.GetFriendlyName()" />
             }
         }
         else if (unwrappedType.IsGenericType && unwrappedType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
         {
             var dkt = unwrappedType.GetGenericArguments()[0];
             var dvt = unwrappedType.GetGenericArguments()[1];
-            var buttonText = $"{dkt.Name} and {dvt.Name} pair.";
+            var buttonText = $"{dkt.GetFriendlyName()} and {dvt.GetFriendlyName()} pair.";
             <DictionaryObjectObject id="@id" Object="Object" SubPath="@SubPath" dictionaryKeyType="@dkt" dictionaryValueType="@dvt" buttonText="@buttonText" onChangeAction="@onChangeAction"/>
         }
         else

--- a/OAT.Blazor.Components/Inputs/ScaffoldInput.razor
+++ b/OAT.Blazor.Components/Inputs/ScaffoldInput.razor
@@ -27,18 +27,18 @@
         <div class="form-group">
             @if (Scaffold.Parameters[i].obj is Scaffold)
             {
-                <label class="font-weight-bold" for="@PathFromKey(i)"><u>@Scaffold.Parameters[i].name</u> : @Scaffold.Parameters[i].type.Name</label>
-                <ScaffoldInput Object="@Object" SubPath="@PathFromKey(i)" ShowConstructorSelect="ShowSubConstructorSelect" ShowSubConstructorSelect="ShowSubConstructorSelect" Assemblies="Assemblies" onChangeAction="onChangeAction"/>
+                <label class="font-weight-bold" for="@PathFromKey(i)"><u>@Scaffold.Parameters[i].name</u> : @Scaffold.Parameters[i].type.GetFriendlyName()</label>
+                <ScaffoldInput Object="@Object" SubPath="@PathFromKey(i)" ShowConstructorSelect="ShowSubConstructorSelect" ShowSubConstructorSelect="ShowSubConstructorSelect" onChangeAction="onChangeAction"/>
         }
             else
             {
                 @if ((Scaffold.Constructor.DeclaringType?.IsArray ?? false) && string.IsNullOrEmpty(Scaffold.Parameters[i].name))
                 {
-                    <label for="@PathFromKey(i)"><u>Length</u> : @Scaffold.Parameters[i].type.Name</label>
+                    <label for="@PathFromKey(i)"><u>Length</u> : @Scaffold.Parameters[i].type.GetFriendlyName()</label>
                 }
                 else
                 {
-                    <label for="@PathFromKey(i)"><u>@Scaffold.Parameters[i].name</u> : @Scaffold.Parameters[i].type.Name</label>
+                    <label for="@PathFromKey(i)"><u>@Scaffold.Parameters[i].name</u> : @Scaffold.Parameters[i].type.GetFriendlyName()</label>
                 }
                 <PropertyInput id="@PathFromKey(i)" Object="@Object" SubPath="@PathFromKey(i)" type="@Scaffold.Parameters[i].type" onChangeAction="onChangeAction"/>
             }

--- a/OAT.Blazor.Components/Inputs/TupleInput.razor
+++ b/OAT.Blazor.Components/Inputs/TupleInput.razor
@@ -7,7 +7,7 @@
         var path = !string.IsNullOrEmpty(SubPath) ? $"{SubPath}.{field.Name}" : field.Name;
         var propId = $"{id}.{field.Name}";
         <div class="form-group">
-            <label for="@propId"><b>@field.Name</b> : @field.FieldType.Name</label>
+            <label for="@propId"><b>@field.Name</b> : @field.FieldType.GetFriendlyName()</label>
             <PropertyInput id="@propId" Object="Object" SubPath="@path" type="field.FieldType" onChangeAction="onChangeAction" />
         </div>
     }

--- a/OAT.Blazor.Components/Inputs/TypesInput.razor
+++ b/OAT.Blazor.Components/Inputs/TypesInput.razor
@@ -45,7 +45,7 @@
 
     protected override void OnInitialized()
     {
-        var newIndex = Array.IndexOf(Types,Types.FirstOrDefault(type => type.Name.Equals(Helpers.GetValueByPropertyOrFieldName(Object, SubPath))));
+        var newIndex = Array.IndexOf(Types, Types.FirstOrDefault(type => type.Name.Equals(Helpers.GetValueByPropertyOrFieldName(Object, SubPath))));
         SelectedType = newIndex < 0 ? 0 : newIndex;
         base.OnInitialized();
     }

--- a/OAT/Analyzer.cs
+++ b/OAT/Analyzer.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CST.OAT
 
                 // Does the name of this class match the Target in the rule? Or has no target been specified
                 // (match all)
-                if (rule.Target is null || (sample?.GetType().Name.Equals(rule.Target, StringComparison.InvariantCultureIgnoreCase) ?? true))
+                if (rule.Target is null || (sample?.GetType().GetFriendlyName().Equals(rule.Target, StringComparison.InvariantCultureIgnoreCase) ?? true))
                 {
                     // If the expression is null the default is that all clauses must be true If we have no
                     // clauses .All will still match

--- a/OAT/Helpers.cs
+++ b/OAT/Helpers.cs
@@ -14,6 +14,28 @@ namespace Microsoft.CST.OAT.Utils
     public static class Helpers
     {
         /// <summary>
+        /// Get the friendly name for a type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static string GetFriendlyName(this Type type)
+        {
+            if (type.IsArray)
+            {
+                var rank = type.GetArrayRank();
+                var commas = rank > 1
+                    ? new string(',', rank - 1)
+                    : "";
+                return GetFriendlyName(type.GetElementType()) + $"[{commas}]";
+            }
+            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                return type.GetGenericArguments()[0].GetFriendlyName() + "?";
+            else if (type.IsGenericType)
+                return type.Name.Split('`')[0] + "<" + string.Join(", ", type.GetGenericArguments().Select(x => GetFriendlyName(x)).ToArray()) + ">";
+            else
+                return type.Name;
+        }
+        /// <summary>
         /// Determines if a Regex is valid or not by checking if a Regex object can be created with it.
         /// </summary>
         /// <param name="pattern"></param>


### PR DESCRIPTION
For example, `Dictionary<String, Int32>` instead of ``Dictionary`2``