### PR TITLE
Update TypesInput.razor

### DIFF
--- a/OAT.Blazor.Components/Inputs/TypesInput.razor
+++ b/OAT.Blazor.Components/Inputs/TypesInput.razor
@@ -5,11 +5,21 @@
 <select class="form-control" id="@id" @bind="SelectedType" data-input-type="types-input">
     @for (int i = 0; i < Types.Length; i++)
     {
-        <option value="@i">@Types[i].FullName</option>
+        @if (UseShortName)
+        {
+            <option value="@i">@Types[i].Name</option>
+        }
+        else
+        {
+            <option value="@i">@Types[i].FullName</option>
+        }
     }
 </select>
 
 @code {
+    [Parameter]
+    public bool UseShortName {get; set; }
+
     [Parameter]
     public Type[] Types { get; set; } = Array.Empty<Type>();
 


### PR DESCRIPTION
Add an option to show the short name and not the full name of objects for relying parties that are using objects from all the same namespace.