### PR TITLE
Add support for List<Enum>

### DIFF
--- a/OAT.Tests/OperationsTests.cs
+++ b/OAT.Tests/OperationsTests.cs
@@ -10,6 +10,12 @@ namespace Microsoft.CST.OAT.Tests
     [TestClass]
     public class OperationsTests
     {
+        enum ContainsTestEnum
+        {
+            Magic,
+            Nothing
+        }
+        
         [ClassInitialize]
         public static void ClassSetup(TestContext _)
         {
@@ -99,6 +105,46 @@ namespace Microsoft.CST.OAT.Tests
             Assert.IsTrue(listAnalyzer.Analyze(ruleList, null, trueListObject).Any());
             Assert.IsFalse(listAnalyzer.Analyze(ruleList, null, falseListObject).Any());
 
+            var trueEnumListObject = new TestObject()
+            {
+                EnumListField = new List<Enum>()
+                {
+                    ContainsTestEnum.Magic
+                }
+            };
+
+            var falseEnumListObject = new TestObject()
+            {
+                EnumListField = new List<Enum>()
+                {
+                    ContainsTestEnum.Nothing
+                }
+            };
+
+            var enumListContains = new Rule("Enum List Contains Any Rule")
+            {
+                Target = "TestObject",
+                Clauses = new List<Clause>()
+                {
+                    new Clause(Operation.ContainsAny,"EnumListField")
+                    {
+                        Data = new List<string>()
+                        {
+                            "Magic"
+                        }
+                    }
+                }
+            };
+
+            var enumListAnalyzer = new Analyzer();
+            ruleList = new List<Rule>() { enumListContains };
+
+            Assert.IsTrue(enumListAnalyzer.Analyze(ruleList, trueEnumListObject).Any());
+            Assert.IsFalse(enumListAnalyzer.Analyze(ruleList, falseEnumListObject).Any());
+
+            Assert.IsTrue(enumListAnalyzer.Analyze(ruleList, null, trueEnumListObject).Any());
+            Assert.IsFalse(enumListAnalyzer.Analyze(ruleList, null, falseEnumListObject).Any());
+            
             var trueStringDictObject = new TestObject()
             {
                 StringDictField = new Dictionary<string, string>()
@@ -348,6 +394,46 @@ namespace Microsoft.CST.OAT.Tests
             Assert.IsTrue(listAnalyzer.Analyze(ruleList, null, trueListObject).Any());
             Assert.IsFalse(listAnalyzer.Analyze(ruleList, null, falseListObject).Any());
 
+            var trueEnumListObject = new TestObject()
+            {
+                EnumListField = new List<Enum>()
+                {
+                    ContainsTestEnum.Magic
+                }
+            };
+
+            var falseEnumListObject = new TestObject()
+            {
+                EnumListField = new List<Enum>()
+                {
+                    ContainsTestEnum.Nothing
+                }
+            };
+
+            var enumListContains = new Rule("Enum List Contains Rule")
+            {
+                Target = "TestObject",
+                Clauses = new List<Clause>()
+                {
+                    new Clause(Operation.Contains,"EnumListField")
+                    {
+                        Data = new List<string>()
+                        {
+                            "Magic"
+                        }
+                    }
+                }
+            };
+
+            var enumListAnalyzer = new Analyzer();
+            ruleList = new List<Rule>() { enumListContains };
+
+            Assert.IsTrue(enumListAnalyzer.Analyze(ruleList, trueEnumListObject).Any());
+            Assert.IsFalse(enumListAnalyzer.Analyze(ruleList, falseEnumListObject).Any());
+
+            Assert.IsTrue(enumListAnalyzer.Analyze(ruleList, null, trueEnumListObject).Any());
+            Assert.IsFalse(enumListAnalyzer.Analyze(ruleList, null, falseEnumListObject).Any());
+            
             var trueStringDictObject = new TestObject()
             {
                 StringDictField = new Dictionary<string, string>()

--- a/OAT.Tests/TestObject.cs
+++ b/OAT.Tests/TestObject.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CST.OAT.Tests
         public string? StringField { get; set; }
         public bool BoolField { get; set; }
         public Dictionary<string, string>? StringDictField { get; set; }
+        public List<Enum>? EnumListField { get; set; }
         public List<string>? StringListField { get; set; }
         public TestObject? NestedObject { get; set; }
         public Dictionary<string, List<string>>? StringListDictField { get; set; }

--- a/OAT/Analyzer.cs
+++ b/OAT/Analyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CST.OAT.Operations;
 using Microsoft.CST.OAT.Utils;
 using Serilog;
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -691,17 +692,35 @@ namespace Microsoft.CST.OAT
                         }
                         if (!found)
                         {
-                            var val = obj?.ToString();
-                            if (val is not null)
+                            if (obj is string strObj)
                             {
-                                valsToCheck.Add(val);
+                                valsToCheck.Add(strObj);
+                            }
+                            else if (obj is IEnumerable enumerableObj && enumerableObj.GetType().IsGenericType)
+                            {
+                                foreach (var innerObj in enumerableObj)
+                                {
+                                    var innerObjString = innerObj?.ToString();
+                                    if (innerObjString is not null)
+                                    {
+                                        valsToCheck.Add(innerObjString);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                var val = obj?.ToString();
+                                if (val is not null)
+                                {
+                                    valsToCheck.Add(val);
+                                }
                             }
                         }
                     }
                 }
                 catch (Exception)
                 {
-                    Log.Debug("Failed to Turn Obect into Values");
+                    Log.Debug("Failed to Turn Object into Values");
                 }
             }
 

--- a/OAT/Operations/ContainsAnyOperation.cs
+++ b/OAT/Operations/ContainsAnyOperation.cs
@@ -147,28 +147,9 @@ namespace Microsoft.CST.OAT.Operations
             {
                 (bool Applies, List<string>? Matches) ClauseAppliesToList(List<string> stateList)
                 {
-                    // If we are dealing with an array on the object side
-                    if (typeHolder is List<string>)
+                    var results = new List<string>();
+                    if (typeHolder is string)
                     {
-                        var foundStates = new List<string>();
-                        foreach (var entry in stateList)
-                        {
-                            if ((!clause.Invert && ClauseData.Contains(entry)) || (clause.Invert && !ClauseData.Contains(entry)))
-                            {
-                                foundStates.Add(entry);
-                            }
-                        }
-                        if (foundStates.Count == 0)
-                        {
-                            return (false, null);
-                        }
-
-                        return (true, foundStates);
-                    }
-                    // If we are dealing with a single string we do a .Contains instead
-                    else if (typeHolder is string)
-                    {
-                        var results = new List<string>();
                         foreach (var datum in stateList)
                         {
                             if (clause.Data.Any(x => (clause.Invert && !datum.Contains(x)) || (!clause.Invert && datum.Contains(x))))
@@ -178,7 +159,17 @@ namespace Microsoft.CST.OAT.Operations
                         }
                         return (results.Any(), clause.Capture ? results : null);
                     }
-                    return (false, new List<string>());
+                    else
+                    {
+                        foreach (var datum in stateList)
+                        {
+                            if (clause.Data.Any(x => (clause.Invert && !datum.Equals(x)) || (!clause.Invert && datum.Equals(x))))
+                            {
+                                results.Add(datum);
+                            }
+                        }
+                        return (results.Any(), clause.Capture ? results : null);
+                    }
                 }
 
                 var result = ClauseAppliesToList(stateOneList);

--- a/OAT/Operations/ContainsOperation.cs
+++ b/OAT/Operations/ContainsOperation.cs
@@ -131,17 +131,8 @@ namespace Microsoft.CST.OAT.Operations
             {
                 (bool Applies, List<string>? Matches) ClauseAppliesToList(List<string> stateList)
                 {
-                    // If we are dealing with an array on the object side
-                    if (typeHolder is List<string>)
-                    {
-                        var res = stateList.Where(x => (!clause.Invert && clause.Data.Contains(x)) || (clause.Invert && !clause.Data.Contains(x)));
-                        if (res.Any())
-                        {
-                            return (true, clause.Capture ? res.ToList() : null);
-                        }
-                    }
                     // If we are dealing with a single string we do a .Contains instead
-                    else if (typeHolder is string)
+                    if (typeHolder is string)
                     {
                         var results = new List<string>();
                         foreach (var datum in stateList)
@@ -153,6 +144,14 @@ namespace Microsoft.CST.OAT.Operations
                             }
                         }
                         return (results.Any(), clause.Capture ? results : null);
+                    }
+                    else
+                    {
+                        var res = stateList.Where(x => (!clause.Invert && clause.Data.Contains(x)) || (clause.Invert && !clause.Data.Contains(x)));
+                        if (res.Any())
+                        {
+                            return (true, clause.Capture ? res.ToList() : null);
+                        }
                     }
                     return (false, new List<string>());
                 }


### PR DESCRIPTION
Object to values can now deconstruct IEnumerable<Enum> into List<string> to be used by operations.

Contains and Contains any support IEnumerable that didn't start as List<string>.