### PR TITLE
Add explicit reference to Newtonsoft.Json 13.x.

### DIFF
--- a/OAT.Tests/OAT.Tests.csproj
+++ b/OAT.Tests/OAT.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="morelinq" Version="3.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Explicitly references `Newtonsoft.Json` 13.0.1. Otherwise, `Microsoft.NET.Test.Sdk` and/or `MSTest.TestAdapter` wind up bringing in 10.0.3 which is vulnerable to [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr). This change is intended to mitigate that risk.