### PR TITLE
provide public api to get delegate by key

### DIFF
--- a/OAT/Analyzer.cs
+++ b/OAT/Analyzer.cs
@@ -740,12 +740,16 @@ namespace Microsoft.CST.OAT
         }
 
         /// <summary>
-        ///     Returns a read only view of the current set of delegates
+        ///     Get the current operation is set for the <see cref="Operation"/> and <paramref name="customOperation"/> pair provided.
+        ///     For default operations, use null for <paramref name="customOperation"/>.
         /// </summary>
-        /// <returns>Immutable dictionary which maps the Operation enum and custom string to the actual OatOperation object which performs actions.</returns>
-        public ImmutableDictionary<(Operation Operation, string CustomOperation), OatOperation> GetDelegates() => Delegates.ToImmutableDictionary();
-        
-        private Dictionary<(Operation Operation, string CustomOperation), OatOperation> Delegates { get; } = new Dictionary<(Operation Operation, string CustomOperation), OatOperation>();
+        /// <param name="operation"></param>
+        /// <param name="customOperation"></param>
+        /// <returns>If the <see cref="OatOperation"/> delegate is set for the given pair, will return the value, otherwise null.</returns>
+        public OatOperation? GetOperation(Operation operation, string? customOperation = null) =>
+            Delegates.TryGetValue((operation, customOperation), out OatOperation value) ? value : null;
+
+        private Dictionary<(Operation Operation, string? CustomOperation), OatOperation> Delegates { get; } = new Dictionary<(Operation Operation, string? CustomOperation), OatOperation>();
 
         private static int FindMatchingParen(string[] splits, int startingIndex)
         {

--- a/OAT/Analyzer.cs
+++ b/OAT/Analyzer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -728,7 +729,7 @@ namespace Microsoft.CST.OAT
         }
 
         /// <summary>
-        ///     Set the OatOperation which will be trigged by the provided Operation (and when Custom, CustomOperation)
+        ///     Set the OatOperation which will be triggered by the provided Operation (and when Custom, CustomOperation)
         /// </summary>
         /// <param name="oatOperation"> The OatOperation </param>
         /// <returns> </returns>
@@ -738,6 +739,12 @@ namespace Microsoft.CST.OAT
             return true;
         }
 
+        /// <summary>
+        ///     Returns a read only view of the current set of delegates
+        /// </summary>
+        /// <returns>Immutable dictionary which maps the Operation enum and custom string to the actual OatOperation object which performs actions.</returns>
+        public ImmutableDictionary<(Operation Operation, string CustomOperation), OatOperation> GetDelegates() => Delegates.ToImmutableDictionary();
+        
         private Dictionary<(Operation Operation, string CustomOperation), OatOperation> Delegates { get; } = new Dictionary<(Operation Operation, string CustomOperation), OatOperation>();
 
         private static int FindMatchingParen(string[] splits, int startingIndex)

--- a/OAT/Analyzer.cs
+++ b/OAT/Analyzer.cs
@@ -908,6 +908,14 @@ namespace Microsoft.CST.OAT
             return (current, captureOut);
         }
 
+        /// <summary>
+        /// Execute the operation for a provided clause.
+        /// </summary>
+        /// <param name="clause"> The Clause to test </param>
+        /// <param name="state1"> object state1 </param>
+        /// <param name="state2"> object state2 </param>
+        /// <param name="captures">Existing captures to be passed to the clause.</param>
+        /// <returns>The <see cref="OperationResult"/> of the operation.</returns>
         public OperationResult GetClauseCapture(Clause clause, object? state1 = null, object? state2 = null, IEnumerable<ClauseCapture>? captures = null)
         {
             if (clause.Field is not null)

--- a/OAT/OAT.csproj
+++ b/OAT/OAT.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AI Rules have clauses that depend on other clauses. The secondary clauses are not stored in the primary list of clauses but still need to be validated. In order to properly extend the WithinClause validation to validate subclauses I need to be able to access the validation delegate for the appropriate subclause type - clauses themselves don't have a reference to the operation so that they are serializable.

This change provides a public api to access the delegates by Operation from the Analyzer which is referenced by a Clause instance. 