### PR TITLE
Make Key property of Clause internal

### DIFF
--- a/OAT.Scripting/OAT.Scripting.csproj
+++ b/OAT.Scripting/OAT.Scripting.csproj
@@ -24,7 +24,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OAT/Clause.cs
+++ b/OAT/Clause.cs
@@ -71,12 +71,6 @@ namespace Microsoft.CST.OAT
         /// <summary>
         /// The Key used for lookups in <see cref="Analyzer"/>
         /// </summary>
-        public (Operation Operation, string CustomOperation) Key
-        {
-            get
-            {
-                return (Operation, CustomOperation ?? "");
-            }
-        }
+        internal (Operation Operation, string CustomOperation) Key => (Operation, CustomOperation ?? "");
     }
 }


### PR DESCRIPTION
Fixes serialization of rules in Attack Surface Analyzer. The Key property is an internal mechanism and doesn't need to be exposed.