### PR TITLE
Remove Code Coverage Flag

### DIFF
--- a/Pipelines/oat-pr.yml
+++ b/Pipelines/oat-pr.yml
@@ -50,7 +50,6 @@ extends:
           poolImage: MSSecurity-1ES-Ubuntu-2204
           poolOs: linux
           projectPath: 'OAT.Tests/OAT.Tests.csproj'
-          dotnetTestArgs: '--coverage --report-trx'
 
     - stage: Build
       dependsOn:

--- a/Pipelines/oat-release.yml
+++ b/Pipelines/oat-release.yml
@@ -49,7 +49,6 @@ extends:
           poolImage: MSSecurity-1ES-Ubuntu-2204
           poolOs: linux
           projectPath: 'OAT.Tests/OAT.Tests.csproj'
-          dotnetTestArgs: '--coverage --report-trx'
 
     - stage: Build
       dependsOn:


### PR DESCRIPTION
Tests fail when enabled without meaningfully debuggable output.