### PR TITLE
Revert "use templates from twcsecurityassurance rather than duplicating in twcdot (#358)"

### DIFF
--- a/Pipelines/oat-release.yml
+++ b/Pipelines/oat-release.yml
@@ -6,8 +6,7 @@ resources:
   repositories:
     - repository: templates
       type: git
-      name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      endpoint: oss-twcsa-repo-reader # service connection
+      name: Data/OSS-Tools-Pipeline-Templates
       ref: refs/tags/v2.0.4
     - repository: 1esPipelines
       type: git


### PR DESCRIPTION
This reverts commit d6c06ba1490094df80300630470479d62721e5cc.

Unfortunately, the ADO repository resource only supports repositories in the same project or same organization. It cannot be used for repositories in other organizations. [Docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema#repository-resource-types)