### PR TITLE
Update NuGet package versions across projects

### DIFF
--- a/OAT.Blazor.Components/OAT.Blazor.Components.csproj
+++ b/OAT.Blazor.Components/OAT.Blazor.Components.csproj
@@ -25,10 +25,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.17" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.17" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.6" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.6" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.19" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.19" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.8" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.8" Condition="'$(TargetFramework)' == 'net9.0'" />
 	<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.4.0.24340" />
   </ItemGroup>

--- a/OAT.Blazor/OAT.Blazor.csproj
+++ b/OAT.Blazor/OAT.Blazor.csproj
@@ -10,10 +10,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.18" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.18" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.19" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.19" PrivateAssets="all" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http.Json" Version="9.0.7" />
+		<PackageReference Include="System.Net.Http.Json" Version="9.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/OAT.Tests/OAT.Tests.csproj
+++ b/OAT.Tests/OAT.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="morelinq" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/OAT/OAT.csproj
+++ b/OAT/OAT.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.7" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump Microsoft.AspNetCore.Components, System.Net.Http.Json, xunit.runner.visualstudio, and System.Collections.Immutable to latest patch versions in their respective project files to address potential bug fixes and security updates.